### PR TITLE
Add Snaplert to website change tracking tools

### DIFF
--- a/cyber-intelligence/osint/domain.md
+++ b/cyber-intelligence/osint/domain.md
@@ -207,6 +207,7 @@ Monitoring websites for changes can be valuable during ongoing investigations or
 
 * [Follow That Page](https://followthatpage.com/) - Change detection and notification service that sends email alerts when monitored web pages are modified.
 * [VisualPing](https://visualping.io/) - Advanced monitoring tool that tracks multiple types of changes on web pages and provides alerts based on specific conditions you define.
+* [Snaplert](https://snaplert.com) - Website change monitoring with AI-powered visual diffs, element-level zone picker, and email alerts. Useful for tracking target page changes with before/after screenshots.
 
 </details>
 


### PR DESCRIPTION
Adds [Snaplert](https://snaplert.com) to the Website Change Tracking section alongside VisualPing and Follow That Page.

Snaplert is useful for security researchers and OSINT analysts who need to monitor target pages for changes:
- AI-powered visual diffs — before/after screenshots with change highlights
- Element-level zone picker to watch specific sections of a page (e.g., just the team page, just a login form)
- Email alerts when changes are detected
- Checks every 5 minutes, 24/7
- Free during open beta (no credit card required)