### PR TITLE
Update Lullar entry — tool is live at com.lullar.com

### DIFF
--- a/cyber-intelligence/osint/username-email.md
+++ b/cyber-intelligence/osint/username-email.md
@@ -40,6 +40,7 @@ Local helper copy: [Email.html](../../.gitbook/assets/Email.html)
 * [Blackbird](https://github.com/p1ngul1n0/blackbird) - Search for usernames across 600+ social networks and websites
 * [AnalyzeID](https://analyzeid.com/username/) - Check username availability across social media platforms and gather basic profile information
 * [IDCrawl](https://www.idcrawl.com/) - Free people search engine aggregating social network information, deep web data, phone numbers, and email addresses
+* [Lullar](https://com.lullar.com/) - Free profile search by email, username or first/last name across 175+ social networks
 * [Instant Username Search](https://instantusername.com/) - Check username availability across multiple social media platforms instantly
 * [KnowEm](https://knowem.com/) - Check username or real name availability across 500+ popular and emerging social media platforms
 
@@ -203,7 +204,6 @@ These tools were previously included but are now deprecated, shut down, or have 
 * [TruMail](https://trumail.io/) - API service is no longer reliably accessible. Use Email Hippo or NeverBounce as alternatives.
 
 **Username Search:**
-* [Lullar Search](https://www.lullar.com/) - Service functionality has declined and results are often limited.
 * [Stalker](https://gitlab.com/Pxmme/stalker) - GitLab repository appears inactive; tool may not be maintained.
 * [finduser](https://github.com/xHak9x/finduser) - Repository archived and no longer maintained. Use Sherlock, Maigret, or Blackbird instead.
 


### PR DESCRIPTION
Lullar is currently listed under **Deprecated or Unreliable Tools** in `cyber-intelligence/osint/username-email.md`. That listing points at the old `lullar.com` domain, which did go offline — but the tool itself has been live and maintained at https://com.lullar.com.

It is a free people-search engine that searches 175+ social platforms by email, username, or first/last name, with no signup required. It is also listed in [soxoj/osint-namecheckers-list](https://github.com/soxoj/osint-namecheckers-list) (maintained by the Maigret author) and [The-Osint-Toolbox/People-Search-OSINT](https://github.com/The-Osint-Toolbox/People-Search-OSINT).

This PR moves the entry out of the deprecated section into the active Username Search Tools list with the live URL, matching the existing entry format.

Disclosure: I run the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)